### PR TITLE
ci: add add_repo_issue_to_gh_project workflow

### DIFF
--- a/.github/workflows/add_repo_issue_to_gh_project.yml
+++ b/.github/workflows/add_repo_issue_to_gh_project.yml
@@ -1,0 +1,17 @@
+---
+
+name: Add Repo Issue to ALD GH project
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/ansible-lockdown/projects/1
+          github-token: ${{ secrets.ALD_GH_PROJECT }}


### PR DESCRIPTION
I have read and understood the contributing guidelines and I signed off my commits.

- [x] I have read and agree to the [contributing guidelines](CONTRIBUTING.md)
- [x] My commits are signed off (`git commit -s`)
- [x] My commits are GPG signed

**Overall Review of Changes:**

Adds the org-standard `add_repo_issue_to_gh_project` GitHub Actions workflow to SUSE15-CIS, bringing it in line with the other maintained Ansible Lockdown repos. The workflow adds newly opened, reopened, or transferred issues to the Ansible Lockdown GitHub project board.

**Issue Fixes:**

None.

**Enhancements:**

- Adds `.github/workflows/add_repo_issue_to_gh_project.yml` (byte-identical to the canonical version already present in sibling repos such as UBUNTU22-CIS and RHEL10-CIS).

**How has this been tested?:**

CI-config only. The workflow file is identical to the version already validated by pre-commit.ci in sibling repos; pre-commit / devel pipeline checks on this PR confirm it lints clean.
