### PR TITLE
meta: restore company to MindPoint Group and SVA gmbh

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@
 galaxy_info:
   author: "Ansible-Lockdown Team"
   description: "Apply the SUSE 15 CIS"
-  company: "MindPoint Group - A Tyto Athene Company and SVA gmbh"
+  company: "MindPoint Group and SVA gmbh"
   license: MIT
   role_name: suse15_cis
   namespace: mindpointgroup


### PR DESCRIPTION
## Overall Review of Changes:
Restores the `galaxy_info.company` value in `meta/main.yml` to `MindPoint Group and SVA gmbh`, dropping the "- A Tyto Athene Company" segment. SUSE15-CIS is a joint MindPoint Group / SVA gmbh benchmark, so the SVA gmbh attribution is retained.

## Issue Fixes:
N/A

## Enhancements:
Metadata attribution correction only (single line).

## How has this been tested?:
`meta/main.yml` parses cleanly as YAML; diff is a single line.
